### PR TITLE
Add a more restrictive mode to the lock file.

### DIFF
--- a/cronjobs/management/commands/cron.py
+++ b/cronjobs/management/commands/cron.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
             filename = os.path.join(tempfile.gettempdir(),
                                     'django_cron.%s.%s' % (LOCK, script))
             try:
-                fd = os.open(filename, os.O_CREAT|os.O_EXCL)
+                fd = os.open(filename, os.O_CREAT|os.O_EXCL, 0644)
 
                 def register():
                     os.close(fd)


### PR DESCRIPTION
os.open's default is 0777. With 0644 some other user can't come along and delete the lock file, letting another cron job run concurrently.

(Editing this through Github; I haven't run tests.)
